### PR TITLE
Fixing invite handling modal

### DIFF
--- a/front-react/src/components/modals/AnswerTeamInviteModalContainer.tsx
+++ b/front-react/src/components/modals/AnswerTeamInviteModalContainer.tsx
@@ -37,6 +37,7 @@ const AnswerTeamInviteModalContainer: React.FC<AnswerTeamInviteModalContainerPro
   const isLoading = useReduxSelector((state) => state.apiCallsInProgress > 0);
   const isMounted = useLifecycleStatus();
 
+  const [isActionPending, setIsActionPending] = useState(false);
   const [step, setStep] = useState(ActionSteps.Question);
   const [currentTeam] = useState(
     localStorage.get<BareTeam>(LocalStorageKeys.currentTeam)
@@ -48,16 +49,19 @@ const AnswerTeamInviteModalContainer: React.FC<AnswerTeamInviteModalContainerPro
     );
 
     if (!result.success || !result.userHasSeveralTeams) {
+      setIsActionPending(false);
       onClose();
       return;
     }
 
     if (isMounted.current) {
+      setIsActionPending(false);
       setStep(ActionSteps.SwitchTeam);
     }
   };
 
   const handleAcceptInvite = async () => {
+    setIsActionPending(true);
     const result = await dispatch(
       acceptTeamInviteAction(requestId, Context.Modal)
     );
@@ -65,6 +69,7 @@ const AnswerTeamInviteModalContainer: React.FC<AnswerTeamInviteModalContainerPro
     if (result.success) {
       await fetchUserTeams();
     } else {
+      setIsActionPending(false);
       onClose();
     }
   };
@@ -84,7 +89,7 @@ const AnswerTeamInviteModalContainer: React.FC<AnswerTeamInviteModalContainerPro
   return (
     <AnswerTeamInviteModal
       isOpened={isOpened}
-      isLoading={isLoading}
+      isLoading={isLoading || isActionPending}
       step={step}
       title={title}
       teamName={teamName}

--- a/front-react/src/redux/reducers/user/user.teams.reducer.ts
+++ b/front-react/src/redux/reducers/user/user.teams.reducer.ts
@@ -13,6 +13,7 @@ const userTeamsReducer = (
       return [];
     /* --------------------------------------------------- */
     case typeFor(Type.getUserTeams, Context.Global, Result.Success):
+    case typeFor(Type.getUserTeams, Context.Modal, Result.Success):
       return action.payload;
     /* --------------------------------------------------- */
     default:


### PR DESCRIPTION
User teams were not displayed after accepting the invite; user was thus unable to see his teams and switch if he wanted to.